### PR TITLE
Baseurl for xml

### DIFF
--- a/src/xml_document.cc
+++ b/src/xml_document.cc
@@ -235,7 +235,7 @@ NAN_METHOD(XmlDocument::ToString)
     if (xmlBufferLength(buf) > 0)
         ret = Nan::New<v8::String>((char*)xmlBufferContent(buf), xmlBufferLength(buf)).ToLocalChecked();
     xmlBufferFree(buf);
-    
+
     return info.GetReturnValue().Set(ret);
 }
 
@@ -317,7 +317,7 @@ xmlParserOption getParserOptions(v8::Local<v8::Object> props) {
     ret |= getParserOption(props, "cdata", XML_PARSE_NOCDATA, false);       // 16384: merge CDATA as text nodes
 
     ret |= getParserOption(props, "noxincnode", XML_PARSE_NOXINCNODE);      // 32768: do not generate XINCLUDE START/END nodes
-    ret |= getParserOption(props, "xinclude", XML_PARSE_NOXINCNODE, false); // 32768: do not generate XINCLUDE START/END nodes
+    ret |= getParserOption(props, "xincnode", XML_PARSE_NOXINCNODE, false); // 32768: do not generate XINCLUDE START/END nodes
 
     ret |= getParserOption(props, "compact", XML_PARSE_COMPACT);            // 65536: compact small text nodes; no modification of the tree allowed afterwards (will possibly crash if you try to modify the tree)
     /*ret |= getParserOption(props, "compact", HTML_PARSE_COMPACT , false);   // 65536: compact small text nodes*/


### PR DESCRIPTION
This PR comprises two changes. I'll describe them as line comments below.

The main purpose of this PR is to add the `baseUrl` option to FromXml. I noticed that this (and a few other options) were already added to FromHtml a long time ago, so I added them in the same way.

I think the two methods should be refactored to move the common code (99% of it) to a common function. If it had been done that way originally, then users of FromXml would have benefited from these extra options added to FromHtml.
